### PR TITLE
fix V773 from PVS-Studio

### DIFF
--- a/giflib/src/gifalloc.c
+++ b/giflib/src/gifalloc.c
@@ -64,6 +64,7 @@ MakeMapObject(int ColorCount,
 
     Object->Colors = (GifColorType *)calloc(ColorCount, sizeof(GifColorType));
     if (Object->Colors == (GifColorType *) NULL) {
+		FREE(Object);
         return ((ColorMapObject *) NULL);
     }
 

--- a/liblept/src/affine.c
+++ b/liblept/src/affine.c
@@ -1303,26 +1303,31 @@ l_uint32  *lines;
  */
 l_int32
 gaussjordan(l_float32  **a,
-            l_float32   *b,
-            l_int32      n)
+	l_float32   *b,
+	l_int32      n)
 {
-l_int32    i, icol, irow, j, k, col, row;
-l_int32   *indexc, *indexr, *ipiv;
-l_float32  maxval, val, pivinv, temp;
+	l_int32    i, icol, irow, j, k, col, row;
+	l_int32   *indexc, *indexr, *ipiv;
+	l_float32  maxval, val, pivinv, temp;
 
-    PROCNAME("gaussjordan");
+	PROCNAME("gaussjordan");
 
-    if (!a)
-        return ERROR_INT("a not defined", procName, 1);
-    if (!b)
-        return ERROR_INT("b not defined", procName, 1);
+	if (!a)
+		return ERROR_INT("a not defined", procName, 1);
+	if (!b)
+		return ERROR_INT("b not defined", procName, 1);
 
-    if ((indexc = (l_int32 *)CALLOC(n, sizeof(l_int32))) == NULL)
-        return ERROR_INT("indexc not made", procName, 1);
-    if ((indexr = (l_int32 *)CALLOC(n, sizeof(l_int32))) == NULL)
-        return ERROR_INT("indexr not made", procName, 1);
-    if ((ipiv = (l_int32 *)CALLOC(n, sizeof(l_int32))) == NULL)
-        return ERROR_INT("ipiv not made", procName, 1);
+	if ((indexc = (l_int32 *)CALLOC(n, sizeof(l_int32))) == NULL)
+		return ERROR_INT("indexc not made", procName, 1);
+	if ((indexr = (l_int32 *)CALLOC(n, sizeof(l_int32))) == NULL) {
+		FREE(indexc);
+		return ERROR_INT("indexr not made", procName, 1);
+	}
+	if ((ipiv = (l_int32 *)CALLOC(n, sizeof(l_int32))) == NULL) {
+		FREE(indexr);
+		FREE(indexc);
+		return ERROR_INT("ipiv not made", procName, 1);
+	}
 
     for (i = 0; i < n; i++) {
         maxval = 0.0;
@@ -1336,6 +1341,9 @@ l_float32  maxval, val, pivinv, temp;
                             icol = k;
                         }
                     } else if (ipiv[k] > 1) {
+						FREE(indexr);
+						FREE(indexc);
+						FREE(ipiv);
                         return ERROR_INT("singular matrix", procName, 1);
                     }
                 }

--- a/liblept/src/bbuffer.c
+++ b/liblept/src/bbuffer.c
@@ -133,8 +133,10 @@ BBUFFER  *bb;
 
     if ((bb = (BBUFFER *)CALLOC(1, sizeof(BBUFFER))) == NULL)
         return (BBUFFER *)ERROR_PTR("bb not made", procName, NULL);
-    if ((bb->array = (l_uint8 *)CALLOC(nalloc, sizeof(l_uint8))) == NULL)
-        return (BBUFFER *)ERROR_PTR("byte array not made", procName, NULL);
+	if ((bb->array = (l_uint8 *)CALLOC(nalloc, sizeof(l_uint8))) == NULL) {
+		FREE(bb);
+		return (BBUFFER *)ERROR_PTR("byte array not made", procName, NULL);
+	}
     bb->nalloc = nalloc;
     bb->nwritten = 0;
 

--- a/liblept/src/boxbasic.c
+++ b/liblept/src/boxbasic.c
@@ -461,8 +461,10 @@ BOXA  *boxa;
     boxa->nalloc = n;
     boxa->refcount = 1;
 
-    if ((boxa->box = (BOX **)CALLOC(n, sizeof(BOX *))) == NULL)
-        return (BOXA *)ERROR_PTR("boxa ptrs not made", procName, NULL);
+	if ((boxa->box = (BOX **)CALLOC(n, sizeof(BOX *))) == NULL) {
+		FREE(boxa);
+		return (BOXA *)ERROR_PTR("boxa ptrs not made", procName, NULL);
+	}
 
     return boxa;
 }
@@ -1144,8 +1146,10 @@ BOXAA  *baa;
 
     if ((baa = (BOXAA *)CALLOC(1, sizeof(BOXAA))) == NULL)
         return (BOXAA *)ERROR_PTR("baa not made", procName, NULL);
-    if ((baa->boxa = (BOXA **)CALLOC(n, sizeof(BOXA *))) == NULL)
-        return (BOXAA *)ERROR_PTR("boxa ptr array not made", procName, NULL);
+	if ((baa->boxa = (BOXA **)CALLOC(n, sizeof(BOXA *))) == NULL) {
+		FREE(baa);
+		return (BOXAA *)ERROR_PTR("boxa ptr array not made", procName, NULL);
+	}
 
     baa->nalloc = n;
     baa->n = 0;

--- a/liblept/src/bytearray.c
+++ b/liblept/src/bytearray.c
@@ -98,8 +98,10 @@ L_BYTEA  *ba;
     if ((ba = (L_BYTEA *)CALLOC(1, sizeof(L_BYTEA))) == NULL)
         return (L_BYTEA *)ERROR_PTR("ba not made", procName, NULL);
 
-    if ((ba->data = (l_uint8 *)CALLOC(nbytes + 1, sizeof(l_uint8))) == NULL)
-        return (L_BYTEA *)ERROR_PTR("ba array not made", procName, NULL);
+	if ((ba->data = (l_uint8 *)CALLOC(nbytes + 1, sizeof(l_uint8))) == NULL) {
+		FREE(ba);
+		return (L_BYTEA *)ERROR_PTR("ba array not made", procName, NULL);
+	}
     ba->nalloc = nbytes + 1;
     ba->refcount = 1;
 

--- a/liblept/src/ccbord.c
+++ b/liblept/src/ccbord.c
@@ -313,8 +313,10 @@ CCBORDA  *ccba;
     ccba->n = 0;
     ccba->nalloc = n;
 
-    if ((ccba->ccb = (CCBORD **)CALLOC(n, sizeof(CCBORD *))) == NULL)
-        return (CCBORDA *)ERROR_PTR("ccba ptrs not made", procName, NULL);
+	if ((ccba->ccb = (CCBORD **)CALLOC(n, sizeof(CCBORD *))) == NULL) {
+		FREE(ccba);
+		return (CCBORDA *)ERROR_PTR("ccba ptrs not made", procName, NULL);
+	}
 
     return ccba;
 }
@@ -378,14 +380,20 @@ PTAA    *local;
     ccb->refcount++;
     if (pixs)
         ccb->pix = pixClone(pixs);
-    if ((boxa = boxaCreate(1)) == NULL)
-        return (CCBORD *)ERROR_PTR("boxa not made", procName, NULL);
+	if ((boxa = boxaCreate(1)) == NULL) {
+		FREE(ccb);
+		return (CCBORD *)ERROR_PTR("boxa not made", procName, NULL);
+	}
     ccb->boxa = boxa;
-    if ((start = ptaCreate(1)) == NULL)
-        return (CCBORD *)ERROR_PTR("start pta not made", procName, NULL);
+	if ((start = ptaCreate(1)) == NULL) {
+		FREE(ccb);
+		return (CCBORD *)ERROR_PTR("start pta not made", procName, NULL);
+	}
     ccb->start = start;
-    if ((local = ptaaCreate(1)) == NULL)
-        return (CCBORD *)ERROR_PTR("local ptaa not made", procName, NULL);
+	if ((local = ptaaCreate(1)) == NULL) {
+		FREE(ccb);
+		return (CCBORD *)ERROR_PTR("local ptaa not made", procName, NULL);
+	}
     ccb->local = local;
 
     return ccb;

--- a/liblept/src/colormap.c
+++ b/liblept/src/colormap.c
@@ -112,8 +112,10 @@ PIXCMAP    *cmap;
         return (PIXCMAP *)ERROR_PTR("cmap not made", procName, NULL);
     cmap->depth = depth;
     cmap->nalloc = 1 << depth;
-    if ((cta = (RGBA_QUAD *)CALLOC(cmap->nalloc, sizeof(RGBA_QUAD))) == NULL)
-        return (PIXCMAP *)ERROR_PTR("cta not made", procName, NULL);
+	if ((cta = (RGBA_QUAD *)CALLOC(cmap->nalloc, sizeof(RGBA_QUAD))) == NULL) {
+		FREE(cmap);
+		return (PIXCMAP *)ERROR_PTR("cta not made", procName, NULL);
+	}
     cmap->array = cta;
     cmap->n = 0;
 
@@ -233,8 +235,10 @@ PIXCMAP  *cmapd;
     if ((cmapd = (PIXCMAP *)CALLOC(1, sizeof(PIXCMAP))) == NULL)
         return (PIXCMAP *)ERROR_PTR("cmapd not made", procName, NULL);
     nbytes = cmaps->nalloc * sizeof(RGBA_QUAD);
-    if ((cmapd->array = (void *)CALLOC(1, nbytes)) == NULL)
-        return (PIXCMAP *)ERROR_PTR("cmap array not made", procName, NULL);
+	if ((cmapd->array = (void *)CALLOC(1, nbytes)) == NULL) {
+		FREE(cmapd);
+		return (PIXCMAP *)ERROR_PTR("cmap array not made", procName, NULL);
+	}
     memcpy(cmapd->array, cmaps->array, nbytes);
     cmapd->n = cmaps->n;
     cmapd->nalloc = cmaps->nalloc;
@@ -1463,10 +1467,14 @@ RGBA_QUAD  *cta;
         return ERROR_INT("cmap not defined", procName, 1);
 
     ncolors = pixcmapGetCount(cmap);
-    if (((rmap = (l_int32 *)CALLOC(ncolors, sizeof(l_int32))) == NULL) ||
-        ((gmap = (l_int32 *)CALLOC(ncolors, sizeof(l_int32))) == NULL) ||
-        ((bmap = (l_int32 *)CALLOC(ncolors, sizeof(l_int32))) == NULL))
-            return ERROR_INT("calloc fail for *map", procName, 1);
+	if (((rmap = (l_int32 *)CALLOC(ncolors, sizeof(l_int32))) == NULL) ||
+		((gmap = (l_int32 *)CALLOC(ncolors, sizeof(l_int32))) == NULL) ||
+		((bmap = (l_int32 *)CALLOC(ncolors, sizeof(l_int32))) == NULL)) {
+		FREE(rmap);
+		FREE(gmap);
+		FREE(bmap);
+		return ERROR_INT("calloc fail for *map", procName, 1);
+	}
     *prmap = rmap;
     *pgmap = gmap;
     *pbmap = bmap;

--- a/liblept/src/colorquant1.c
+++ b/liblept/src/colorquant1.c
@@ -1001,12 +1001,31 @@ PIX       *pixd;
         buf2r = (l_int32 *)CALLOC(w, sizeof(l_int32));
         buf2g = (l_int32 *)CALLOC(w, sizeof(l_int32));
         buf2b = (l_int32 *)CALLOC(w, sizeof(l_int32));
-        if (!bufu8r || !bufu8g || !bufu8b)
-            return (PIX *)ERROR_PTR("uint8 mono line buf not made",
-                procName, NULL);
-        if (!buf1r || !buf1g || !buf1b || !buf2r || !buf2g || !buf2b)
-            return (PIX *)ERROR_PTR("mono line buf not made", procName, NULL);
-
+		if (!bufu8r || !bufu8g || !bufu8b) {
+			FREE(bufu8r); 
+			FREE(bufu8g);
+			FREE(bufu8b);
+			FREE(buf1r);
+			FREE(buf1g);
+			FREE(buf1b);
+			FREE(buf2r);
+			FREE(buf2g);
+			FREE(buf2b);
+			return (PIX *)ERROR_PTR("uint8 mono line buf not made",
+				procName, NULL);
+		}
+		if (!buf1r || !buf1g || !buf1b || !buf2r || !buf2g || !buf2b) {
+			FREE(bufu8r);
+			FREE(bufu8g);
+			FREE(bufu8b);
+			FREE(buf1r);
+			FREE(buf1g);
+			FREE(buf1b);
+			FREE(buf2r);
+			FREE(buf2g);
+			FREE(buf2b);
+			return (PIX *)ERROR_PTR("mono line buf not made", procName, NULL);
+		}
             /* Start by priming buf2; line 1 is above line 2 */
         pixGetRGBLine(pixs, 0, bufu8r, bufu8g, bufu8b);
         for (j = 0; j < w; j++) {
@@ -1228,12 +1247,16 @@ CQCELL   **cqca;   /* one array for each octree level */
         return (CQCELL ***)ERROR_PTR("cqcaa not made", procName, NULL);
     for (level = 0; level <= CQ_NLEVELS; level++) {
         ncells = 1 << (3 * level);
-        if ((cqca = (CQCELL **)CALLOC(ncells, sizeof(CQCELL *))) == NULL)
-            return (CQCELL ***)ERROR_PTR("cqca not made", procName, NULL);
+		if ((cqca = (CQCELL **)CALLOC(ncells, sizeof(CQCELL *))) == NULL) {
+			FREE(cqcaa);
+			return (CQCELL ***)ERROR_PTR("cqca not made", procName, NULL);
+		}
         cqcaa[level] = cqca;
         for (i = 0; i < ncells; i++) {
-            if ((cqca[i] = (CQCELL *)CALLOC(1, sizeof(CQCELL))) == NULL)
-                return (CQCELL ***)ERROR_PTR("cqc not made", procName, NULL);
+			if ((cqca[i] = (CQCELL *)CALLOC(1, sizeof(CQCELL))) == NULL) {
+				FREE(cqcaa);
+				return (CQCELL ***)ERROR_PTR("cqc not made", procName, NULL);
+			}
         }
     }
 
@@ -1327,10 +1350,15 @@ l_uint32  *rtab, *gtab, *btab;
         return ERROR_INT("&*tab not defined", procName, 1);
     if ((rtab = (l_uint32 *)CALLOC(256, sizeof(l_uint32))) == NULL)
         return ERROR_INT("rtab not made", procName, 1);
-    if ((gtab = (l_uint32 *)CALLOC(256, sizeof(l_uint32))) == NULL)
-        return ERROR_INT("gtab not made", procName, 1);
-    if ((btab = (l_uint32 *)CALLOC(256, sizeof(l_uint32))) == NULL)
-        return ERROR_INT("btab not made", procName, 1);
+	if ((gtab = (l_uint32 *)CALLOC(256, sizeof(l_uint32))) == NULL) {
+		FREE(rtab);
+		return ERROR_INT("gtab not made", procName, 1);
+	}
+	if ((btab = (l_uint32 *)CALLOC(256, sizeof(l_uint32))) == NULL) {
+		FREE(rtab);
+		FREE(gtab);
+		return ERROR_INT("btab not made", procName, 1);
+	}
     *prtab = rtab;
     *pgtab = gtab;
     *pbtab = btab;
@@ -1678,12 +1706,21 @@ PIXCMAP        *cmap;
 
     if ((narray = (l_int32 *)CALLOC(size, sizeof(l_int32))) == NULL)
         return (PIX *)ERROR_PTR("narray not made", procName, NULL);
-    if ((rarray = (l_int32 *)CALLOC(size, sizeof(l_int32))) == NULL)
-        return (PIX *)ERROR_PTR("rarray not made", procName, NULL);
-    if ((garray = (l_int32 *)CALLOC(size, sizeof(l_int32))) == NULL)
-        return (PIX *)ERROR_PTR("garray not made", procName, NULL);
-    if ((barray = (l_int32 *)CALLOC(size, sizeof(l_int32))) == NULL)
-        return (PIX *)ERROR_PTR("barray not made", procName, NULL);
+	if ((rarray = (l_int32 *)CALLOC(size, sizeof(l_int32))) == NULL) {
+		FREE(narray);
+		return (PIX *)ERROR_PTR("rarray not made", procName, NULL);
+	}
+	if ((garray = (l_int32 *)CALLOC(size, sizeof(l_int32))) == NULL) {
+		FREE(narray);
+		FREE(rarray);
+		return (PIX *)ERROR_PTR("garray not made", procName, NULL);
+	}
+	if ((barray = (l_int32 *)CALLOC(size, sizeof(l_int32))) == NULL) {
+		FREE(narray);
+		FREE(rarray);
+		FREE(garray);
+		return (PIX *)ERROR_PTR("barray not made", procName, NULL);
+	}
 
         /* Place the pixels in octcube leaves. */
     datas = pixGetData(pixs);
@@ -1970,10 +2007,30 @@ PIXCMAP   *cmap;
     buf2r = (l_int32 *)CALLOC(w, sizeof(l_int32));
     buf2g = (l_int32 *)CALLOC(w, sizeof(l_int32));
     buf2b = (l_int32 *)CALLOC(w, sizeof(l_int32));
-    if (!bufu8r || !bufu8g || !bufu8b)
-        return ERROR_INT("uint8 line buf not made", procName, 1);
-    if (!buf1r || !buf1g || !buf1b || !buf2r || !buf2g || !buf2b)
-        return ERROR_INT("mono line buf not made", procName, 1);
+	if (!bufu8r || !bufu8g || !bufu8b) {
+		FREE(bufu8r);
+		FREE(bufu8g);
+		FREE(bufu8b);
+		FREE(buf1r);
+		FREE(buf1g);
+		FREE(buf1b);
+		FREE(buf2r);
+		FREE(buf2g);
+		FREE(buf2b);
+		return ERROR_INT("uint8 line buf not made", procName, 1);
+	}
+	if (!buf1r || !buf1g || !buf1b || !buf2r || !buf2g || !buf2b) {
+		FREE(bufu8r);
+		FREE(bufu8g);
+		FREE(bufu8b);
+		FREE(buf1r);
+		FREE(buf1g);
+		FREE(buf1b);
+		FREE(buf2r);
+		FREE(buf2g);
+		FREE(buf2b);
+		return ERROR_INT("mono line buf not made", procName, 1);
+	}
 
         /* Start by priming buf2; line 1 is above line 2 */
     pixGetRGBLine(pixs, 0, bufu8r, bufu8g, bufu8b);
@@ -2283,15 +2340,22 @@ PIXCMAP   *cmap;
                                        rtab, gtab, btab, &index);
 /*                fprintf(stderr, "rval = %d, gval = %d, bval = %d, index = %d\n",
                         rval, gval, bval, index); */
-                switch (bpp) {
-                case 4:
-                    SET_DATA_QBIT(lined, j, index);
-                    break;
-                case 8:
-                    SET_DATA_BYTE(lined, j, index);
-                    break;
-                default:
-                    return (PIX *)ERROR_PTR("bpp not 4 or 8!", procName, NULL);
+				switch (bpp) {
+				case 4:
+					SET_DATA_QBIT(lined, j, index);
+					break;
+				case 8:
+					SET_DATA_BYTE(lined, j, index);
+					break;
+				default:
+					for (i = 0; i < nbase; i++)
+						FREE(oqca[i]);
+					FREE(oqca);
+					FREE(rtab);
+					FREE(gtab);
+					FREE(btab);
+
+					return (PIX *)ERROR_PTR("bpp not 4 or 8!", procName, NULL);					
                     break;
                 }
                 oqca[index]->n += 1.0;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'p' pointer. A memory leak is possible.

for example,
(https://github.com/charlesw/tesseract-vs2012/blob/master/giflib/src/gifalloc.c#L67)
etc... many places.